### PR TITLE
Use Todoist's REST API v2

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,8 @@
 
 
 # some global varibles
-projects_api_url <- "https://api.todoist.com/rest/v1/projects"
-tasks_api_url    <- "https://api.todoist.com/rest/v1/tasks"
+projects_api_url <- "https://api.todoist.com/rest/v2/projects"
+tasks_api_url    <- "https://api.todoist.com/rest/v2/tasks"
 
 empty_project_df <- data.frame(
   id = integer(),


### PR DESCRIPTION
v8 was deprecated on December 5, 2022.

I didn't notice any other incompatibility, but I'm not familiar with R. Here's the migration guide from v8: https://developer.todoist.com/sync/v9/#migrating-from-v8